### PR TITLE
Membership issue template: value with comments instead of placeholder…

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership-request.yml
+++ b/.github/ISSUE_TEMPLATE/membership-request.yml
@@ -53,9 +53,9 @@ body:
   type: textarea
   attributes:
     label: List of contributions to the cert-manager project
-    placeholder: |
-      - PRs reviewed / authored
-      - Issues responded to
-      - Slack conversations you helped in
+    value: |
+      <!-- PRs reviewed / authored -->
+      <!-- Issues responded to -->
+      <!-- Slack conversations you helped in -->
   validations:
     required: true


### PR DESCRIPTION
… for contributions. I am about to use the issue template, and once I start writing, the placeholder is gone. And I have a very short memory. 😉 I think it's common to have commented text in issue/PR templates.