### PR TITLE
Governance: I realized that GitHub Members do have privileges and can `/close` and `/ok-to-test`

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -166,11 +166,10 @@ project and who can participate in lazy consensus and votes.
 
 ### Becoming a Maintainer
 
-Any existing Approver can become a cert-manager maintainer. Maintainers should
-be proficient in Go; have expertise in at least one of the domains (Kubernetes,
-PKI, ACME); have the time and ability to meet the maintainer expectations above;
-and demonstrate the ability to work with the existing maintainers and project
-processes.
+Anyone can become a cert-manager maintainer. Maintainers should be proficient in
+Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have
+the time and ability to meet the maintainer expectations above; and demonstrate
+the ability to work with the existing maintainers and project processes.
 
 To become a maintainer, start by expressing interest to existing maintainers.
 Existing maintainers will then ask you to demonstrate the qualifications above

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -73,6 +73,18 @@ GitHub members are encouraged to engage with the mailing list [cert-manager-dev@
 
 No extra responsabilities.
 
+### GitHub Member Privileges
+
+- GitHub Members can be assigned to issues and pull requests via `/assign
+  @username`, they can self-assign with `/assign`, and people can ask members
+  for reviews with a /cc @username.
+- GitHub Members do not need `/ok-to-test`. The CI run automatically on their
+  pull requests.
+- GitHub Members can use the command `/ok-to-test` to enable tests on pull
+  requests.
+- GitHub Members can manage pull requests and issues with `/close` and
+  `/reopen`.
+
 ## Reviewer
 
 The mission of the reviewer is to read through PRs for quality and correctness
@@ -98,6 +110,7 @@ need to repeat the process for each repository.
 
 ### Reviewer Responsibilities
 
+- Review code changes when Prow selects you on a pull request.
 - When possible, review pull requests, triage issues, and fix bugs in their
   areas of expertise.
 - Ensure that all changes go through the project's code review and integration
@@ -105,7 +118,7 @@ need to repeat the process for each repository.
 
 ### Reviewer Privileges
 
-- Able to `/lgtm` on pull requests.
+- Reviewers can `/lgtm` on pull requests.
 
 ## Approver
 
@@ -153,10 +166,11 @@ project and who can participate in lazy consensus and votes.
 
 ### Becoming a Maintainer
 
-Anyone can become a cert-manager maintainer. Maintainers should be proficient in
-Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have
-the time and ability to meet the maintainer expectations above; and demonstrate
-the ability to work with the existing maintainers and project processes.
+Any existing Approver can become a cert-manager maintainer. Maintainers should
+be proficient in Go; have expertise in at least one of the domains (Kubernetes,
+PKI, ACME); have the time and ability to meet the maintainer expectations above;
+and demonstrate the ability to work with the existing maintainers and project
+processes.
 
 To become a maintainer, start by expressing interest to existing maintainers.
 Existing maintainers will then ask you to demonstrate the qualifications above


### PR DESCRIPTION
After reading https://github.com/kubernetes/community/blob/master/community-membership.md#responsibilities-and-privileges, I realized that our own Prow system is configured in the same way. For example, GitHub Members can `/close` or `/ok-to-test` ~but also `/lgtm`~.

~I also discovered that the `reviewers` section in the `OWNERS` file isn't actually used to select who can `/lgtm`. It is only used by Blunderbuss to suggest automatically a reviewer for a pull request that was just submitted.~

> ~Any collaborator on the repo (i.e., members of the GitHub org) may use the `/lgtm` command, **whether or not they are selected as a reviewer** or approver by this plugin. (See the section [Blunderbuss Selection Mechanism](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#blunderbuss-selection-mechanism) for reviewer and approver selection algorithm.)~

~I am unsure whether this change requires an explicit approval from all the maintainers since it aims at reflecting what the current situation is, but I think we should have a discussion whether we are OK with the fact that GitHub Members are able to `/lgtm`.~

**Update:** as Tim pointed out, `/lgtm` is correctly restricted to Reviewers. 