### PR TITLE
Governance: rephrase "anyone" to reflect the actual expectation

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -153,10 +153,11 @@ project and who can participate in lazy consensus and votes.
 
 ### Becoming a Maintainer
 
-Anyone can become a cert-manager maintainer. Maintainers should be proficient in
-Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have
-the time and ability to meet the maintainer expectations above; and demonstrate
-the ability to work with the existing maintainers and project processes.
+Any existing Approver can become a cert-manager maintainer. Maintainers should
+be proficient in Go; have expertise in at least one of the domains (Kubernetes,
+PKI, ACME); have the time and ability to meet the maintainer expectations above;
+and demonstrate the ability to work with the existing maintainers and project
+processes.
 
 To become a maintainer, start by expressing interest to existing maintainers.
 Existing maintainers will then ask you to demonstrate the qualifications above


### PR DESCRIPTION
The start of the document says that each role builds and requires the previous role.

Thus, I rephrased "Anyone can become a cert-manager maintainer" to "Any existing Approver can become a cert-manager maintainer" to match what we say at the start of the document.
