### PR TITLE
Steering: propose the first batch of steering committee members

### DIFF
--- a/STEERING.md
+++ b/STEERING.md
@@ -8,7 +8,9 @@ for cert-manager adopters.
 
 The members of the Steering Committee are:
 
-- TBD
+- Florian Liebhart (Volkswagen)
+- Erik Godding Boye (Zenior AS)
+- Spyros Synodinos (Giantswarm)
 
 ## Steering Committee Responsibilities
 


### PR DESCRIPTION
After posting the announcement about the opening of the steering committee on Slack [1], Spyros showed his interest to join the steering committee. I also proposed Florian and Erik who accepted.

Since the 7 seats are currently empty, I directly added them to the list.

**Due dilligence:**

- Florian Liebhart (Volkswagen) operates cert-manager on large Kubernetes clusters at Volkswagen.
- Erik Godding Boye (Zenior AS) works as a long-term consultant for a client who uses cert-manager on large Kubernetes clusters.
- Spyros Synodinos (Giantswarm) operates cert-manager on large Kubernetes clusters at Giantswarm.


@FlorianLiebhart @erikgb @ssyno Is the above correct? Are you OK with being added as steering committee members?

Note that we still have four empty seats, people can request to join the steering committee at any time. 

**When is the first meeting?** Since we plan on running the steering committee meetings once per quarter, I think the first meeting should take place early in 2024.

As per the document STEERING.md, I need someone from the maintainers to volunteer to "nominate" the candidates with me:
> Candidates for membership will be nominated by current Steering Committee members or by cert-manager maintainers. To be accepted as a candidate, a person must have **at least two nominators from this group**.




[1]: https://kubernetes.slack.com/archives/C4NV3DWUC/p1700564024652739