### PR TITLE
Request maintainer status for @ThatsMrTalbot

### DIFF
--- a/maintainers.csv
+++ b/maintainers.csv
@@ -7,3 +7,4 @@ Maël Valais,maelvls,Venafi
 Irbe Krumina,irbekrm,Tailscale
 Ashley Davis,sgtcodfish,Venafi
 Tim Ramlot,inteon,Venafi
+Adam Talbot,thatsmrtalbot,Venafi


### PR DESCRIPTION
Further to our conversation during standup  and following the steps laid out in the GOVERNANCE.md I am requesting maintainer status:

> Any existing Approver can become a cert-manager maintainer. Maintainers should be proficient in Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have the time and ability to meet the maintainer expectations above; and demonstrate the ability to work with the existing maintainers and project processes.
> 
> To become a maintainer, start by expressing interest to existing maintainers. Existing maintainers will then ask you to demonstrate the qualifications above by contributing PRs, doing code reviews, and other such tasks under their guidance. After several months of working together, maintainers will decide whether to grant maintainer status.

As part of my Venafi role part of my responsibilities is to contribute to cert-manager, so I have the time and availablity to meet the maintainer expectations. As for my proficiency, I hope my work with you in the last 5 months has shown this.

Based on the governance document it was not clear how "maintainers will decide whether to grant maintainer status" so it was decided on the call that we would use "lazy consensus" as described in the "Maintainer Decision-Making" documentation. This can be done as comments on this PR for visibility. 

