### PR TITLE
Add erikgb as maintainer

### DIFF
--- a/maintainers.csv
+++ b/maintainers.csv
@@ -7,3 +7,4 @@ Maël Valais,maelvls,Venafi
 Ashley Davis,sgtcodfish,Venafi
 Tim Ramlot,inteon,Venafi
 Adam Talbot,thatsmrtalbot,Venafi
+Erik Godding Boye,erikgb,Zenior


### PR DESCRIPTION
Erik (@erikgb) has been an important contributor to cert-manager and more specifically trust-manager.
- The improvements Erik has made to trust-manager have improved the project's usefulness and correctness (he has both contributed directly through PRs and indirectly by reviewing PRs).
- Erik also contributed to other controllers like approver-policy and cert-manager.
- He has been joining a lot of our stand-ups and is a trustworthy contributor.

Adding Erik as a maintainer will diversify our maintainers team and it will allow us to give him admin privileges on the trust-manager project, so he can cut releases of trust-manager when required (see https://github.com/cert-manager/community/blob/main/GOVERNANCE.md for requirements wrt. admins).

I (@inteon) think @erikgb is an important part of our community and for that reason must receive the privileges required to contribute optimally. I would trust @erikgb with more admin privileges, but think it is better to restrict his privileges to the actions he is interested in (in case of compromise of his account), additionally this will reduce the scope of the perceived responsibilities that come with these privileges (both for Erik and the rest of the community, eg. no one will ping him to do a cert-manager release).

> I'd like us to approve this appointment using lazy consensus:
> 
> 🧑‍💻 Participants: @cert-manager-maintainers
> 📢 Deadline: July 19th, 2024 23:59 UTC
> 🚨 Note: to speed up the process, you may answer with a 👍 or a comment stating that you are lazy to help reach consensus before the deadline.