### PR TITLE
Add ARI to the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,6 +38,17 @@ including:
 
 ## Roadmap Items
 
+### Support for ACME Renewal Information (ARI)
+
+ARI provides a much cleaner method for renewing certificates using the ACME protocol, and comes with the benefit that
+Let's Encrypt provide exemptions from rate limits if ARI is used correctly.
+
+With the knowledge that the ACME issuer is the most widely used in cert-manager, we'd like to adopt ARI to take
+advantage of the benefits.
+
+For background, see the [Let's Encrypt](https://letsencrypt.org/2024/04/25/guide-to-integrating-ari-into-existing-acme-clients.html)
+guide on adopting ARI.
+
 ### Adoption of Upstream Changes
 
 Continue to support latest versions, new APIs for upstream Kubernetes and related upstream projects.


### PR DESCRIPTION
In the cert-manager biweekly meeting on 2024-07-25 we discussed [ARI](https://letsencrypt.org/2024/04/25/guide-to-integrating-ari-into-existing-acme-clients.html) which helps with renewing ACME certs.

One of the action items from that meeting was to adopt ARI into the cert-manager roadmap explicitly, given how obvious its inclusion seems to be.

As part of the documented process for changing the roadmap, I'll share this in Slack. We've already discussed this in a biweekly, so it might not be particularly valuable to discuss again but I'm open to that if needed!