### PR TITLE
Update governance docs around code of conduct violations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,6 +6,22 @@ The latest version of the upstream CNCF Code of Conduct is at https://github.com
 
 If the version reproduced below is out of date, the Code of Conduct which applies to the cert-manager project is the latest version upstream.
 
+## cert-manager Project Code of Conduct Committee
+
+Given the size of the team involved with cert-manager, there is no explicitly
+defined separate team of people responsible for policing the code of conduct
+for matters which fall exclusively under the [jurisdiction](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md) of the cert-manager project.
+
+If a committee is needed to evaluate a potential violation of the Code of Conduct,
+that team shall be made up of both the steering committee and all maintainers.
+
+Any decisions made by the Code of Conduct committee should seek unanimous consent,
+but failing that should fall back to a majority vote.
+
+If the alleged violator is in the steering committee or the maintainer group,
+that person is ineligible to sit on the committee. The same is true for anyone
+in the group who has a [conflict of interest](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md#conflicts-of-interest).
+
 ## CNCF Community Code of Conduct v1.3
 
 Other languages available:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -23,6 +23,19 @@ but failing that should fall back to a majority vote.
 If the alleged violator is in the steering committee or the maintainer group,
 that person is ineligible to sit on the committee. The same is true for anyone
 in the group who has a [conflict of interest](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md#conflicts-of-interest).
+Importantly, note the [CNCF Transfer by Project CoC Responders](https://github.com/cncf/foundation/blob/316b2515c076b2355420f7ddfe80140a5a3d48ae/code-of-conduct/coc-committee-jurisdiction-policy.md#transfer-by-project-coc-responders) 
+section. If a majority of potential committee members have hard conflicts of interest,
+then the reported issue should be transferred to the CNCF CoC Committee.
+
+To make a report which falls under the jurisdiction of the cert-manager Code of Conduct
+committee, a user can email `cert-manager-maintainers@googlegroups.com`, which is readable
+only by maintainers. If the user has concerns about contacting all maintainers they can
+reach out to an individual maintainer or steering committee member.
+
+If the reporter doesn't feel comfortable reaching out to any individual maintainer or
+steering committee member, they're encouraged to reach out to the CNCF CoC Committee directly.
+More details are in the "Reporting" section in the copied code of conduct below.
+
 
 ## CNCF Community Code of Conduct v1.3
 
@@ -98,6 +111,7 @@ Examples of unacceptable behavior include but are not limited to:
   professional setting
 
 The following behaviors are also prohibited:
+
 * Providing knowingly false or misleading information in connection with a Code of Conduct investigation or otherwise intentionally tampering with an investigation.
 * Retaliating against a person because they reported an incident or provided information about an incident as a witness.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,7 +13,9 @@ defined separate team of people responsible for policing the code of conduct
 for matters which fall exclusively under the [jurisdiction](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md) of the cert-manager project.
 
 If a committee is needed to evaluate a potential violation of the Code of Conduct,
-that team shall be made up of both the steering committee and all maintainers.
+that team shall be made up of both the steering committee and maintainers. All
+steering committee members and all maintainers are invited, and all are expected to
+attend if they're able to.
 
 Any decisions made by the Code of Conduct committee should seek unanimous consent,
 but failing that should fall back to a majority vote.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -313,8 +313,20 @@ project for at least one year from the date of their removal.
 #### Project Permissions and Removal
 
 If someone with an assigned level is undergoing an investigation by any
-committee with jurisdiction under the Code of Conduct, they should have all
-permissions removed temporarily while the investigation is underway.
+committee with jurisdiction under the Code of Conduct, it may be approrpriate
+for that users to have all permissions removed temporarily while the investigation
+is underway, as specified under [Interim Protective Measures](https://github.com/cncf/foundation/blob/316b2515c076b2355420f7ddfe80140a5a3d48ae/code-of-conduct/coc-incident-resolution-procedures.md#interim-protective-measures)
+in the CNCF incident resolution process.
+
+This could include removal from the GitHub organization, GCP projects, 1password or any
+other relevant space. This should coincide with any notifications made
+to the accused person, [as detailed](https://github.com/cncf/foundation/blob/316b2515c076b2355420f7ddfe80140a5a3d48ae/code-of-conduct/coc-incident-resolution-procedures.md#notification-to-the-accused-person)
+in the CNCF incident resolution process:
+
+> While the investigation is ongoing, the CoC Committee shall determine in its discretion
+> whether, how, and when to notify the accused person, and how much information to share
+> about the nature of the allegations, if any, taking into consideration risks of retaliation,
+> evidence tampering or destruction, or witness tampering that might result from the notification.
 
 If someone violates the Code of Conduct to a level such that removal from the
 project is recommended, they must immediately have all permissions removed

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -307,8 +307,8 @@ GitHub issue). The same rules apply for members of the steering committee.
 
 If a committee with jurisdiction under the Code of Conduct recommends a person
 be removed from the project, then after the conclusion (if applicable) of any
-appeals, that person will be removed and will not be eligible to re-join the
-project.
+appeals, that person will be removed and will not be eligible to rejoin the
+project for at least one year from the date of their removal.
 
 #### Project Permissions and Removal
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -225,12 +225,6 @@ If a maintainer is no longer interested in or cannot perform the duties listed
 above, they should move themselves to emeritus status. If necessary, this can
 also occur through the decision-making process outlined above.
 
-A review of the [`MAINTAINERS.md`](./MAINTAINERS.md) file is performed every
-year by the current maintainers. During this review, the maintainers that have
-not been active in the last 18 months are asked whether they would like to
-become an emeritus maintainer, they are expected to respond within 30 days. If
-they do not respond, they will automatically be moved to emeritus status.
-
 ## Admin
 
 An admin is a maintainer who has admin privileges on the cert-manager
@@ -248,8 +242,6 @@ Prow). Then, create an issue on the [community][] repository and mention each
 maintainer. Each maintainer will need to comment on the issue to express their
 approval.
 
-[community]: https://github.com/cert-manager/community
-
 ### Admin Privileges
 
 - Can change settings in the GitHub organization (e.g., remove protected
@@ -263,3 +255,72 @@ approval.
 - Must be available to perform admin-related tasks (add a GitHub member, promote
   a GitHub user to "Owner", add someone to the GCP projects, etc.)
 - Must be responsible with the privileges granted to them.
+
+## Removing Contributors
+
+### Stepping Down
+
+Anyone who has reached any level within the cert-manager project can step down
+at any time.
+
+GitHub Members, Reviewers, Approvers, Maintainers and Admins should give notice
+of their intent to step down by raising an issue on the [community][] repo, so
+that their permissions can be revoked for security reasons.
+
+### Timing Out
+
+#### Maintainers
+
+A review of the [`MAINTAINERS.md`](./MAINTAINERS.md) file is performed every
+year by active current maintainers. During this review, the maintainers that
+have not been active in the last 18 months are asked whether they would like to
+become an emeritus maintainer and they are expected to respond within 30 days.
+
+If they do not respond, they will automatically be moved to emeritus status.
+
+#### Other Levels
+
+For security reasons, anyone at any level who isn't actively involved in the
+project for over a year is liable to be timed out upon review by an active
+maintainer.
+
+Anyone who is timed out can reach out to a maintainer to request to be
+reinstated to their previous level.
+
+There is no regularly scheduled check for any org level except for maintainer;
+timing out non-maintainers is ad-hoc.
+
+### Emeritus Status
+
+Anyone who has reached the "Maintainer" level will be added to the list of
+"emeriti" maintainers in `MAINTAINERS.md` upon stepping down or timing out.
+This is a marker of thanks for people who were involved in shaping the project.
+
+### Removal
+
+The cert-manager project abides by the code of conduct in [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
+
+Everyone interacting with the project must abide by this code of conduct, whether
+officially assigned one of the levels listed in this document or if simply
+interacting with the project (e.g. by joining a meeting or commenting on a
+GitHub issue). The same rules apply for members of the steering committee.
+
+If a committee with jurisdiction under the Code of Conduct recommends a person
+be removed from the project, then after the conclusion (if applicable) of any
+appeals, that person will be removed and will not be eligible to re-join the
+project.
+
+#### Project Permissions and Removal
+
+If someone with an assigned level is undergoing an investigation by any
+committee with jurisdiction under the Code of Conduct, they should have all
+permissions removed temporarily while the investigation is underway.
+
+If someone violates the Code of Conduct to a level such that removal from the
+project is recommended, they must immediately have all permissions removed
+from all cert-manager repos (if they hadn't already had permissions removed
+on a temporary basis).
+
+Maintainers removed in this fashion are not eligible for emeritus status.
+
+[community]: https://github.com/cert-manager/community

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -71,7 +71,7 @@ GitHub members are encouraged to engage with the mailing list [cert-manager-dev@
 
 ### GitHub Member Responsibilities
 
-No extra responsabilities.
+No extra responsibilities.
 
 ### GitHub Member Privileges
 
@@ -313,7 +313,7 @@ project for at least one year from the date of their removal.
 #### Project Permissions and Removal
 
 If someone with an assigned level is undergoing an investigation by any
-committee with jurisdiction under the Code of Conduct, it may be approrpriate
+committee with jurisdiction under the Code of Conduct, it may be appropriate
 for that users to have all permissions removed temporarily while the investigation
 is underway, as specified under [Interim Protective Measures](https://github.com/cncf/foundation/blob/316b2515c076b2355420f7ddfe80140a5a3d48ae/code-of-conduct/coc-incident-resolution-procedures.md#interim-protective-measures)
 in the CNCF incident resolution process.

--- a/STEERING.md
+++ b/STEERING.md
@@ -24,6 +24,8 @@ The Steering Committee’s responsibilities are to:
    broader community.
 4. Provide neutral mediation for non-technical disputes.
 5. Develop and maintain a project continuity plan.
+6. Sit on the "Code of Conduct Committee" in the event that a violation of the
+   Code of Conduct is reported
 
 ## Steering Committee Membership
 


### PR DESCRIPTION
It was recommended in our graduation review (see #35) that we:

> ...add a process for removing Maintainers (and SC members) for reasons other than inactivity, such as violating the CoC or disruptive behavior.

This commit attempts to codify that removal process.

Most of the legwork for the process is already done in the CNCF [foundation repo](https://github.com/cncf/foundation/tree/main/code-of-conduct).

Note that this expands the scope of the steering committee slightly by adding a new requirement, and this PR obviously changes our governance process. As such, this PR will go through a lazy consensus process and steering committee members will be explicitly asked to review.