### PR TITLE
Add Trilok Geer to Steering Committee

### DIFF
--- a/STEERING.md
+++ b/STEERING.md
@@ -11,6 +11,7 @@ The members of the Steering Committee are:
 - Florian Liebhart ([@FlorianLiebhart](https://github.com/FlorianLiebhart)) ([Volkswagen](https://www.volkswagen-group.com/en))
 - Spyros Synodinos ([@ssyno](https://github.com/ssyno)) ([Giantswarm](https://www.giantswarm.io/))
 - Ian Arsenault ([@ianarsenault](https://github.com/ianarsenault)) ([Snowplow](https://snowplow.io/))
+- Trilok Geer ([@TrilokGeer](https://github.com/TrilokGeer)) ([Red Hat](https://www.redhat.com/en))
 
 ## Steering Committee Responsibilities
 


### PR DESCRIPTION
In #40 Trilok was proposed as the latest member of the cert-manager Steering Committee. Since he has two sponsors and has confirmed in that issue that he's willing to take part, and given there are still seats free on the Steering Committee, he should be clear to join.

This PR adds him!