### PR TITLE
Add hjoshi123 as maintainer

### DIFF
--- a/maintainers.csv
+++ b/maintainers.csv
@@ -8,3 +8,4 @@ Ashley Davis,sgtcodfish,CyberArk
 Tim Ramlot,inteon,CyberArk
 Adam Talbot,thatsmrtalbot,Epic Games
 Erik Godding Boye,erikgb,Zenior
+Hemant Joshi,hjoshi123,Walmart


### PR DESCRIPTION
Hemant (@hjoshi123 ) has been an important contributor to cert-manager.

After joining the project, Hemant has worked on several important features, in particular, gateway-api ListenerSet support and renewal policy, and assisted with reviewing PRs from community contributors. As Hemant is located in the Mountain West area of the USA, he cannot join our stand-ups due to time zone differences. But he usually joins our (now) weekly development meetings and engages in discussions. Adding Hemant as a maintainer will diversify our maintainer team and increase the capacity to review and merge from contributors. All current maintainers are located in Europe, which means that by adding Hemant to the maintainer team, we will extend our capabilities across time zones and KubeCon NA participation. I have worked together with Hemant on several tasks, and I find him very knowledgeable and trustworthy.

I (@erikgb) think @hjoshi123 is an important part of our community and, for that reason, must receive the privileges required to contribute optimally. All [CNCF maintainers are granted access to free GitHub Copilot Enterprise](https://contribute.cncf.io/blog/2025/12/16/github-copilot-enterprise-for-maintainers/), which I am using more and more, not only to improve my own PRs, but also in reviewing PRs from contributors. And by promoting Hemant to maintainer, he will also get access to this feature.

> Dear maintainers, I'd like us to reach an agreement on the following matter using lazy consensus:
Add hjoshi123 as maintainer: https://github.com/cert-manager/community/pull/67
:technologist: Participants: [@cert-manager-maintainers](https://kubernetes.slack.com/admin/user_groups)
:loudspeaker: Deadline: March 6th, 2026 23:59 UTC
:rotating_light: Note: to speed up the process, you may answer on the PR with a :+1: or a comment stating that you are lazy to help reach consensus before the deadline.